### PR TITLE
Fix demo page error

### DIFF
--- a/demo/basicoverlay.html
+++ b/demo/basicoverlay.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-
+<html>
 <head>
     <title>Style Tool Demo</title>
     <script type="text/javascript" src="./openseadragon/openseadragon.min.js"></script>
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/paper.js/0.12.17/paper-full.js"></script>
     <link rel="stylesheet" href="./demo.css">
-
     <script type="module">
         import { PaperOverlay } from '../src/js/paper-overlay.mjs';
         import {RotationControlOverlay} from '../src/js/rotationcontrol.mjs'
@@ -32,8 +31,8 @@
         viewer.addHandler('open', () => {
             new RotationControlOverlay(viewer);
         });
-        
-        
+
+
     </script>
 </head>
 <body>
@@ -41,7 +40,6 @@
         <div class="demo">
             <h3>Paper Overlay Demo</h3>
             <div id="viewer" class="viewer"></div>
-            
         </div>
     </div>
 </body>

--- a/demo/brush.html
+++ b/demo/brush.html
@@ -6,7 +6,6 @@
     <link rel="stylesheet" href="./demo.css">
 
     <script type="module">
-        import { AnnotationToolbar } from '../src/js/annotationtoolbar.mjs';
         import{ AnnotationToolkit } from '../src/js/annotationtoolkit.mjs';
         // Basic viewer setup
         let viewer = window.viewer = OpenSeadragon({

--- a/demo/brush.html
+++ b/demo/brush.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
+<html>
 <head>
     <title>Brush Tool Demo</title>
     <script type="text/javascript" src="./openseadragon/openseadragon.min.js"></script>
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/paper.js/0.12.17/paper-full.js"></script>
     <link rel="stylesheet" href="./demo.css">
-
     <script type="module">
         import{ AnnotationToolkit } from '../src/js/annotationtoolkit.mjs';
         // Basic viewer setup
@@ -60,9 +60,9 @@
                 <p>Toggle Erase Mode (Optional): If you want to switch to Erase Mode, click the "Erase" button in the Brush Toolbar. The button will become active, indicating that you are in Erase Mode. Furthermore, you can click e on your keyboard to turn erase mode on and off.</p>
                 <p>Start Drawing or Erasing: To draw on the canvas, click and drag the mouse pointer to create brush strokes. If you are in Erase Mode, you can use the brush to erase existing shapes by drawing over them.</p>
                 <p>Changing brush radius during drawing: To change the brush radius while drawing, you can use the mouse wheel to increase or decrease the brush size.</p>
-                <p>Finalizing Shape: When you are satisfied with the drawn area, release the mouse click to finalize the shape. </p>             </div>
+                <p>Finalizing Shape: When you are satisfied with the drawn area, release the mouse click to finalize the shape. </p>
+            </div>
         </div>
     </div>
-
 </body>
 </html>

--- a/demo/demo.html
+++ b/demo/demo.html
@@ -1,10 +1,11 @@
 <!DOCTYPE html>
+<html>
 <head>
-   <title>Demo - OSD Annotation</title>
-   <script type="text/javascript" src="./openseadragon/openseadragon.min.js"></script>
-   <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/paper.js/0.12.17/paper-full.js"></script>
-   <script type="module" src="./demo.mjs"></script>
-   <link rel="stylesheet" href="./demo.css">
+    <title>Demo - OSD Annotation</title>
+    <script type="text/javascript" src="./openseadragon/openseadragon.min.js"></script>
+    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/paper.js/0.12.17/paper-full.js"></script>
+    <script type="module" src="./demo.mjs"></script>
+    <link rel="stylesheet" href="./demo.css">
 </head>
 <body>
     <div class="content">
@@ -24,5 +25,5 @@
             <div id="local-viewer" class="viewer"></div>
         </div>
     </div>
-    
 </body>
+</html>

--- a/demo/ellipse.html
+++ b/demo/ellipse.html
@@ -6,7 +6,6 @@
     <link rel="stylesheet" href="./demo.css">
 
     <script type="module">
-        import { AnnotationToolbar } from '../src/js/annotationtoolbar.mjs';
         import{ AnnotationToolkit } from '../src/js/annotationtoolkit.mjs';
         // Basic viewer setup
         let viewer = OpenSeadragon({
@@ -47,7 +46,7 @@
                 // annotationToolkit.addFeatureCollections(x, true, viewer.world.getItemAt(1));
             });
         });
-        
+
     </script>
 </head>
 <body>

--- a/demo/ellipse.html
+++ b/demo/ellipse.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
+<html>
 <head>
     <title>Ellipse Tool Demo</title>
     <script type="text/javascript" src="./openseadragon/openseadragon.min.js"></script>
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/paper.js/0.12.17/paper-full.js"></script>
     <link rel="stylesheet" href="./demo.css">
-
     <script type="module">
         import{ AnnotationToolkit } from '../src/js/annotationtoolkit.mjs';
         // Basic viewer setup
@@ -46,7 +46,6 @@
                 // annotationToolkit.addFeatureCollections(x, true, viewer.world.getItemAt(1));
             });
         });
-
     </script>
 </head>
 <body>
@@ -79,5 +78,5 @@
             <div id="example-viewer" class="viewer"></div>
         </div>
     </div>
-
+</body>
 </html>

--- a/demo/index.html
+++ b/demo/index.html
@@ -1,18 +1,19 @@
 <!DOCTYPE html>
+<html>
 <head>
     <title>OSD-Paperjs-Annotation Demos</title>
     <script type="text/javascript" src="./openseadragon/openseadragon.min.js"></script>
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/paper.js/0.12.17/paper-full.js"></script>
     <script type="module" src="./demo.mjs"></script>
     <link rel="stylesheet" href="./demo.css">
- </head>
- <body>
-     <div class="content">
-         <div class="demo">
-             <h3>Basic viewer</h3>
-             <div id="basic-viewer" class="viewer"></div>
-         </div>
-         <div>
+</head>
+<body>
+    <div class="content">
+        <div class="demo">
+            <h3>Basic viewer</h3>
+            <div id="basic-viewer" class="viewer"></div>
+        </div>
+        <div>
             <h3>List of demos</h3>
             <ul>
                 <li><a href="./demo.html">Full UI demo</a></li>
@@ -28,9 +29,8 @@
                 <li><a href="./ellipse.html">Ellipse tool</a></li>
                 <li><a href="./rotation.html">Rotation control tool</a></li>
             </ul>
-            
-         </div>
-     </div>
-     
-     
- </body>
+
+        </div>
+    </div>
+</body>
+</html>

--- a/demo/linestring.html
+++ b/demo/linestring.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<html>
 <head>
     <title>Linestring Tool Demo</title>
     <script type="text/javascript" src="./openseadragon/openseadragon.min.js"></script>
@@ -80,7 +81,7 @@
             </div>
             <div>
             </div>
-
         </div>
-    </body>
+    </div>
+</body>
 </html>

--- a/demo/linestring.html
+++ b/demo/linestring.html
@@ -6,7 +6,6 @@
     <link rel="stylesheet" href="./demo.css">
 
     <script type="module">
-        import { AnnotationToolbar } from '../src/js/annotationtoolbar.mjs';
         import{ AnnotationToolkit } from '../src/js/annotationtoolkit.mjs';
         // Basic viewer setup
         let viewer = OpenSeadragon({
@@ -47,7 +46,7 @@
                 // annotationToolkit.addFeatureCollections(x, true, viewer.world.getItemAt(1));
             });
         });
-        
+
     </script>
 </head>
 <body>
@@ -81,7 +80,7 @@
             </div>
             <div>
             </div>
-            
+
         </div>
     </body>
 </html>

--- a/demo/point.html
+++ b/demo/point.html
@@ -6,7 +6,6 @@
     <link rel="stylesheet" href="./demo.css">
 
     <script type="module">
-        import { AnnotationToolbar } from '../src/js/annotationtoolbar.mjs';
         import{ AnnotationToolkit } from '../src/js/annotationtoolkit.mjs';
         // Basic viewer setup
         let viewer = window.viewer = OpenSeadragon({
@@ -49,7 +48,7 @@
                 // annotationToolkit.addFeatureCollections(x, true, viewer.world.getItemAt(1));
             });
         });
-        
+
     </script>
 </head>
 <body>
@@ -78,7 +77,7 @@
                     The Point Tool is designed to work with other annotation items created using supported tools. It allows you to interact with these annotations and efficiently manage them on the map.
                 </p>
             </div>
-            
+
             </div>
         </div>
 

--- a/demo/point.html
+++ b/demo/point.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
+<html>
 <head>
     <title>Point Tool Demo</title>
     <script type="text/javascript" src="./openseadragon/openseadragon.min.js"></script>
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/paper.js/0.12.17/paper-full.js"></script>
     <link rel="stylesheet" href="./demo.css">
-
     <script type="module">
         import{ AnnotationToolkit } from '../src/js/annotationtoolkit.mjs';
         // Basic viewer setup
@@ -77,9 +77,7 @@
                     The Point Tool is designed to work with other annotation items created using supported tools. It allows you to interact with these annotations and efficiently manage them on the map.
                 </p>
             </div>
-
-            </div>
         </div>
-
-    </body>
+    </div>
+</body>
 </html>

--- a/demo/polygon.html
+++ b/demo/polygon.html
@@ -4,7 +4,6 @@
     <script type="text/javascript" src="./openseadragon/openseadragon.min.js"></script>
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/paper.js/0.12.17/paper-full.js"></script>
     <link rel="stylesheet" href="./demo.css">
-
     <script type="module">
         import{ AnnotationToolkit } from '../src/js/annotationtoolkit.mjs';
         // Basic viewer setup
@@ -55,36 +54,33 @@
             <h3>Polygon Tool Demo</h3>
             <div id="brush-viewer" class="viewer"></div>
             <div>
-                    <h4>How to Use the Polygon Tool:</h4>
-                    <p>
-                        The Polygon Tool allows you to draw and edit polygons on the map. Follow these steps to use it effectively:
-                    </p>
-                    <ol>
-                        <li><strong>Adding a New Polygon:</strong> To start drawing a new polygon, first add a new feature, select the "Polygon Tool" icon from the toolbar (polygon icon). Click anywhere on the map to add the first point of the polygon. Then, click or drag to add additional points to the polygon. To complete the polygon, click on the first point again, or simply double-click anywhere on the map.</li>
-                        <li><strong>Editing a Polygon:</strong> To edit an existing polygon, click and drag any of its points to move them to a new location. To remove a point and reshape the polygon, click on the point and press the 'Delete' key.</li>
-                        <li><strong>Erasing:</strong> To erase parts of a polygon, enable the "Eraser" mode by clicking the "Eraser" button in the toolbar. Then, click on a segment of the polygon to remove it.</li>
-                        <li><strong>Simplifying:</strong> To simplify the polygon and reduce the number of points, click the "Simplify" button in the toolbar. This will remove redundant points while maintaining the overall shape of the polygon.</li>
-                        <li><strong>Undo and Redo:</strong> To undo or redo your actions, use the keyboard shortcuts 'Ctrl + Z' and 'Ctrl + Shift + Z', respectively.</li>
-                    </ol>
-                    <p>
-                        The Polygon Tool makes it easy to draw and modify complex shapes on the map.
-                    </p>
-                </div>
-                <div>
-                    <h4>Keyboard Shortcuts:</h4>
-                    <ul>
-                        <li><strong>Click:</strong> Click to add new points to the polygon.</li>
-                        <li><strong>Double-click:</strong> Double-click to finish drawing the polygon.</li>
-                        <li><strong>Click and Drag:</strong> Click and drag to add or move points.</li>
-                        <li><strong>Delete:</strong> Press the 'Delete' key to remove a selected point.</li>
-                        <li><strong>Ctrl + Z:</strong> Undo your last action.</li>
-                        <li><strong>Ctrl + Shift + Z:</strong> Redo your last undone action.</li>
-                    </ul>
-                </div>
-                <div>
-                </div>
-
+                <h4>How to Use the Polygon Tool:</h4>
+                <p>
+                    The Polygon Tool allows you to draw and edit polygons on the map. Follow these steps to use it effectively:
+                </p>
+                <ol>
+                    <li><strong>Adding a New Polygon:</strong> To start drawing a new polygon, first add a new feature, select the "Polygon Tool" icon from the toolbar (polygon icon). Click anywhere on the map to add the first point of the polygon. Then, click or drag to add additional points to the polygon. To complete the polygon, click on the first point again, or simply double-click anywhere on the map.</li>
+                    <li><strong>Editing a Polygon:</strong> To edit an existing polygon, click and drag any of its points to move them to a new location. To remove a point and reshape the polygon, click on the point and press the 'Delete' key.</li>
+                    <li><strong>Erasing:</strong> To erase parts of a polygon, enable the "Eraser" mode by clicking the "Eraser" button in the toolbar. Then, click on a segment of the polygon to remove it.</li>
+                    <li><strong>Simplifying:</strong> To simplify the polygon and reduce the number of points, click the "Simplify" button in the toolbar. This will remove redundant points while maintaining the overall shape of the polygon.</li>
+                    <li><strong>Undo and Redo:</strong> To undo or redo your actions, use the keyboard shortcuts 'Ctrl + Z' and 'Ctrl + Shift + Z', respectively.</li>
+                </ol>
+                <p>
+                    The Polygon Tool makes it easy to draw and modify complex shapes on the map.
+                </p>
             </div>
-
-    </body>
+            <div>
+                <h4>Keyboard Shortcuts:</h4>
+                <ul>
+                    <li><strong>Click:</strong> Click to add new points to the polygon.</li>
+                    <li><strong>Double-click:</strong> Double-click to finish drawing the polygon.</li>
+                    <li><strong>Click and Drag:</strong> Click and drag to add or move points.</li>
+                    <li><strong>Delete:</strong> Press the 'Delete' key to remove a selected point.</li>
+                    <li><strong>Ctrl + Z:</strong> Undo your last action.</li>
+                    <li><strong>Ctrl + Shift + Z:</strong> Redo your last undone action.</li>
+                </ul>
+            </div>
+        </div>
+    </div>
+</body>
 </html>

--- a/demo/polygon.html
+++ b/demo/polygon.html
@@ -6,7 +6,6 @@
     <link rel="stylesheet" href="./demo.css">
 
     <script type="module">
-        import { AnnotationToolbar } from '../src/js/annotationtoolbar.mjs';
         import{ AnnotationToolkit } from '../src/js/annotationtoolkit.mjs';
         // Basic viewer setup
         let viewer = window.viewer = OpenSeadragon({
@@ -47,7 +46,7 @@
                 // annotationToolkit.addFeatureCollections(x, true, viewer.world.getItemAt(1));
             });
         });
-        
+
     </script>
 </head>
 <body>
@@ -84,7 +83,7 @@
                 </div>
                 <div>
                 </div>
-                
+
             </div>
 
     </body>

--- a/demo/raster.html
+++ b/demo/raster.html
@@ -6,7 +6,6 @@
     <link rel="stylesheet" href="./demo.css">
 
     <script type="module">
-        import { AnnotationToolbar } from '../src/js/annotationtoolbar.mjs';
         import{ AnnotationToolkit } from '../src/js/annotationtoolkit.mjs';
         // Basic viewer setup
         let viewer = OpenSeadragon({
@@ -47,7 +46,7 @@
                 // annotationToolkit.addFeatureCollections(x, true, viewer.world.getItemAt(1));
             });
         });
-        
+
         // let exampleviewer = OpenSeadragon({
         //     element: 'example-viewer',
         //     prefixUrl: "https://openseadragon.github.io/openseadragon/images/",
@@ -65,11 +64,11 @@
         // exampleviewer.addHandler('open', () => {
         //     let exPaperScope = new paper.PaperScope(); // Create a new PaperScope
         //     exPaperScope.setup('example-canvas'); // Set up Paper.js with the specified canvas ID
-        
+
         //     // Create the AnnotationToolkit instance for the example viewer
         //     let exAnnotationToolkit = new AnnotationToolkit(exampleviewer);
         //     exAnnotationToolkit.addAnnotationUI({tools:["transform", "raster"], addButton:false, addFileButton:false});
-        
+
         //     $.get('./tissue-annotation.json').then(x => exAnnotationToolkit.addFeatureCollections(x));
         // });
     </script>

--- a/demo/raster.html
+++ b/demo/raster.html
@@ -116,6 +116,7 @@
                 <div id="example-viewer" class="viewer"></div>
             </div>
         </div>
+        <canvas id="example-canvas" style="display: none;"></canvas>
     </div>
     </body>
 </html>

--- a/demo/raster.html
+++ b/demo/raster.html
@@ -4,7 +4,6 @@
     <script type="text/javascript" src="./openseadragon/openseadragon.min.js"></script>
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/paper.js/0.12.17/paper-full.js"></script>
     <link rel="stylesheet" href="./demo.css">
-
     <script type="module">
         import{ AnnotationToolkit } from '../src/js/annotationtoolkit.mjs';
         // Basic viewer setup
@@ -117,6 +116,6 @@
                 <div id="example-viewer" class="viewer"></div>
             </div>
         </div>
-
-    </body>
+    </div>
+</body>
 </html>

--- a/demo/raster.html
+++ b/demo/raster.html
@@ -46,30 +46,30 @@
             });
         });
 
-        // let exampleviewer = OpenSeadragon({
-        //     element: 'example-viewer',
-        //     prefixUrl: "https://openseadragon.github.io/openseadragon/images/",
-        //     tileSources: {
-        //         type: 'image',
-        //         url: './tissue.jpg',
-        //         buildPyramid: true
-        //     },
-        //     minZoomImageRatio: 0.01,
-        //     visibilityRatio: 0,
-        //     crossOriginPolicy: 'Anonymous',
-        //     ajaxWithCredentials: false
-        // });
+        let exampleviewer = OpenSeadragon({
+            element: 'example-viewer',
+            prefixUrl: "https://openseadragon.github.io/openseadragon/images/",
+            tileSources: {
+                type: 'image',
+                url: './tissue.jpg',
+                buildPyramid: true
+            },
+            minZoomImageRatio: 0.01,
+            visibilityRatio: 0,
+            crossOriginPolicy: 'Anonymous',
+            ajaxWithCredentials: false
+        });
 
-        // exampleviewer.addHandler('open', () => {
-        //     let exPaperScope = new paper.PaperScope(); // Create a new PaperScope
-        //     exPaperScope.setup('example-canvas'); // Set up Paper.js with the specified canvas ID
+        exampleviewer.addHandler('open', () => {
+            let exPaperScope = new paper.PaperScope(); // Create a new PaperScope
+            exPaperScope.setup('example-canvas'); // Set up Paper.js with the specified canvas ID
 
-        //     // Create the AnnotationToolkit instance for the example viewer
-        //     let exAnnotationToolkit = new AnnotationToolkit(exampleviewer);
-        //     exAnnotationToolkit.addAnnotationUI({tools:["transform", "raster"], addButton:false, addFileButton:false});
+            // Create the AnnotationToolkit instance for the example viewer
+            let exAnnotationToolkit = new AnnotationToolkit(exampleviewer);
+            exAnnotationToolkit.addAnnotationUI({tools:["transform", "raster"], addButton:false, addFileButton:false});
 
-        //     $.get('./tissue-annotation.json').then(x => exAnnotationToolkit.addFeatureCollections(x));
-        // });
+            $.get('./tissue-annotation.json').then(x => exAnnotationToolkit.addFeatureCollections(x));
+        });
     </script>
 </head>
 <body>
@@ -117,5 +117,5 @@
             </div>
         </div>
     </div>
-</body>
+    </body>
 </html>

--- a/demo/raster.html
+++ b/demo/raster.html
@@ -68,7 +68,7 @@
             let exAnnotationToolkit = new AnnotationToolkit(exampleviewer);
             exAnnotationToolkit.addAnnotationUI({tools:["transform", "raster"], addButton:false, addFileButton:false});
 
-            $.get('./tissue-annotation.json').then(x => exAnnotationToolkit.addFeatureCollections(x));
+            fetch('./tissue-annotation.json').then(r => r.json()).then(x => exAnnotationToolkit.addFeatureCollections(x));
         });
     </script>
 </head>

--- a/demo/rectangle.html
+++ b/demo/rectangle.html
@@ -4,7 +4,6 @@
     <script type="text/javascript" src="./openseadragon/openseadragon.min.js"></script>
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/paper.js/0.12.17/paper-full.js"></script>
     <link rel="stylesheet" href="./demo.css">
-
     <script type="module">
         import{ AnnotationToolkit } from '../src/js/annotationtoolkit.mjs';
         // Basic viewer setup
@@ -84,10 +83,9 @@
                     </li>
                     <li><strong>Finish Modifying:</strong> Once you are done creating or modifying the rectangle,
                         release the mouse button.</li>
+                </ol>
              </div>
         </div>
-
     </div>
-
 </body>
 </html>

--- a/demo/rectangle.html
+++ b/demo/rectangle.html
@@ -6,7 +6,6 @@
     <link rel="stylesheet" href="./demo.css">
 
     <script type="module">
-        import { AnnotationToolbar } from '../src/js/annotationtoolbar.mjs';
         import{ AnnotationToolkit } from '../src/js/annotationtoolkit.mjs';
         // Basic viewer setup
         let viewer = OpenSeadragon({
@@ -49,8 +48,8 @@
                 // annotationToolkit.addFeatureCollections(x, true, viewer.world.getItemAt(1));
             });
         });
-        
-        
+
+
     </script>
 </head>
 <body>
@@ -87,7 +86,7 @@
                         release the mouse button.</li>
              </div>
         </div>
-        
+
     </div>
 
 </body>

--- a/demo/rotation.html
+++ b/demo/rotation.html
@@ -7,8 +7,9 @@
 
 
     <script type="module">
-        import{ AnnotationToolkit } from '../src/js/annotationtoolkit.mjs';
-        // Basic viewer setup
+      import {RotationControlOverlay} from '../src/js/rotationcontrol.mjs'
+
+      // Basic viewer setup
         let viewer = OpenSeadragon({
             element: 'rotating-viewer',
             prefixUrl: "https://openseadragon.github.io/openseadragon/images/",
@@ -23,7 +24,9 @@
             ajaxWithCredentials: false
         });
 
-        viewer.addHandler('open', () => {});
+        viewer.addHandler('open', () => {
+            new RotationControlOverlay(viewer);
+        });
     </script>
  </head>
  <body>

--- a/demo/rotation.html
+++ b/demo/rotation.html
@@ -7,8 +7,7 @@
 
 
     <script type="module">
-        import {RotationControlOverlay} from '../src/js/rotationcontrol.mjs'
-
+        import{ AnnotationToolkit } from '../src/js/annotationtoolkit.mjs';
         // Basic viewer setup
         let viewer = OpenSeadragon({
             element: 'rotating-viewer',
@@ -25,7 +24,39 @@
         });
 
         viewer.addHandler('open', () => {
-            new RotationControlOverlay(viewer)
+            let paperScope = new paper.PaperScope(); // Create a new PaperScope
+            paperScope.setup('brush-canvas'); // Set up Paper.js with the specified canvas ID
+
+            // Create the AnnotationToolkit instance with annotationUI selecting a tool and add feature collections
+            let annotationToolkit = new AnnotationToolkit(viewer);
+            annotationToolkit.addAnnotationUI({tools:["select"], addButton:false, addFileButton:false});
+
+            $.get('./demo-annotation.json').then(x => annotationToolkit.addFeatureCollections(x));
+        });
+
+        let exampleviewer = OpenSeadragon({
+            element: 'example-viewer',
+            prefixUrl: "https://openseadragon.github.io/openseadragon/images/",
+            tileSources: {
+                type: 'image',
+                url: './tissue.jpg',
+                buildPyramid: true
+            },
+            minZoomImageRatio: 0.01,
+            visibilityRatio: 0,
+            crossOriginPolicy: 'Anonymous',
+            ajaxWithCredentials: false
+        });
+
+        exampleviewer.addHandler('open', () => {
+            let exPaperScope = new paper.PaperScope(); // Create a new PaperScope
+            exPaperScope.setup('example-canvas'); // Set up Paper.js with the specified canvas ID
+
+            // Create the AnnotationToolkit instance for the example viewer
+            let exAnnotationToolkit = new AnnotationToolkit(exampleviewer);
+            exAnnotationToolkit.addAnnotationUI({tools:["select"], addButton:false, addFileButton:false});
+
+            fetch('./tissue-annotation.json').then(r=>r.json()).then(x => exAnnotationToolkit.addFeatureCollections(x));
         });
     </script>
  </head>
@@ -80,4 +111,6 @@
              </div>
          </div>
      </div>
+     <canvas id="example-canvas" style="display:none;"></canvas>
+     <canvas id="brush-canvas" style="display:none;"></canvas>
  </body>

--- a/demo/rotation.html
+++ b/demo/rotation.html
@@ -23,41 +23,7 @@
             ajaxWithCredentials: false
         });
 
-        viewer.addHandler('open', () => {
-            let paperScope = new paper.PaperScope(); // Create a new PaperScope
-            paperScope.setup('brush-canvas'); // Set up Paper.js with the specified canvas ID
-
-            // Create the AnnotationToolkit instance with annotationUI selecting a tool and add feature collections
-            let annotationToolkit = new AnnotationToolkit(viewer);
-            annotationToolkit.addAnnotationUI({tools:["select"], addButton:false, addFileButton:false});
-
-            $.get('./demo-annotation.json').then(x => annotationToolkit.addFeatureCollections(x));
-        });
-
-        let exampleviewer = OpenSeadragon({
-            element: 'example-viewer',
-            prefixUrl: "https://openseadragon.github.io/openseadragon/images/",
-            tileSources: {
-                type: 'image',
-                url: './tissue.jpg',
-                buildPyramid: true
-            },
-            minZoomImageRatio: 0.01,
-            visibilityRatio: 0,
-            crossOriginPolicy: 'Anonymous',
-            ajaxWithCredentials: false
-        });
-
-        exampleviewer.addHandler('open', () => {
-            let exPaperScope = new paper.PaperScope(); // Create a new PaperScope
-            exPaperScope.setup('example-canvas'); // Set up Paper.js with the specified canvas ID
-
-            // Create the AnnotationToolkit instance for the example viewer
-            let exAnnotationToolkit = new AnnotationToolkit(exampleviewer);
-            exAnnotationToolkit.addAnnotationUI({tools:["select"], addButton:false, addFileButton:false});
-
-            fetch('./tissue-annotation.json').then(r=>r.json()).then(x => exAnnotationToolkit.addFeatureCollections(x));
-        });
+        viewer.addHandler('open', () => {});
     </script>
  </head>
  <body>
@@ -111,6 +77,4 @@
              </div>
          </div>
      </div>
-     <canvas id="example-canvas" style="display:none;"></canvas>
-     <canvas id="brush-canvas" style="display:none;"></canvas>
  </body>

--- a/demo/rotation.html
+++ b/demo/rotation.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<html>
 <head>
     <title>Rotation Control Demo</title>
     <script type="text/javascript" src="./openseadragon/openseadragon.min.js"></script>
@@ -10,40 +11,40 @@
       import {RotationControlOverlay} from '../src/js/rotationcontrol.mjs'
 
       // Basic viewer setup
-        let viewer = OpenSeadragon({
-            element: 'rotating-viewer',
-            prefixUrl: "https://openseadragon.github.io/openseadragon/images/",
-            tileSources: {
-                type: 'image',
-                url: 'https://openseadragon.github.io/example-images/grand-canyon-landscape-overlooking.jpg',
-                buildPyramid: false
-            },
-            minZoomImageRatio: 0.01,
-            visibilityRatio: 0,
-            crossOriginPolicy: 'Anonymous',
-            ajaxWithCredentials: false
-        });
+      let viewer = OpenSeadragon({
+        element: 'rotating-viewer',
+        prefixUrl: "https://openseadragon.github.io/openseadragon/images/",
+        tileSources: {
+          type: 'image',
+          url: 'https://openseadragon.github.io/example-images/grand-canyon-landscape-overlooking.jpg',
+          buildPyramid: false
+        },
+        minZoomImageRatio: 0.01,
+        visibilityRatio: 0,
+        crossOriginPolicy: 'Anonymous',
+        ajaxWithCredentials: false
+      });
 
-        viewer.addHandler('open', () => {
-            new RotationControlOverlay(viewer);
-        });
+      viewer.addHandler('open', () => {
+        new RotationControlOverlay(viewer);
+      });
     </script>
- </head>
- <body>
-     <div class="content">
-         <div class="demo">
-             <h3>Rotation Control Overlay Demo</h3>
-             <div id="rotating-viewer" class="viewer"></div>
-             <div>
+</head>
+<body>
+    <div class="content">
+        <div class="demo">
+            <h3>Rotation Control Overlay Demo</h3>
+            <div id="rotating-viewer" class="viewer"></div>
+            <div>
                 <h4>How to use:</h4>
                 <p>Toggle the controller using the button on the upper left toolbar.</p>
                 <p>Rotate the image using the following options:
-                    <ul>
-                        <li>Click the control boxes at the cardinal directions (N, E, S, W) to jump to those angles</li>
-                        <li>Click and drag the cross-hair controller to the desired center point for the rotation</li>
-                        <li>Click and drag the indicator dot to directly set the orientation</li>
-                        <li>Click and drag other places on the viewer. A line shows you the axis between the center point and your cursor, for alignment with features in the image. </li>
-                    </ul>
+                <ul>
+                    <li>Click the control boxes at the cardinal directions (N, E, S, W) to jump to those angles</li>
+                    <li>Click and drag the cross-hair controller to the desired center point for the rotation</li>
+                    <li>Click and drag the indicator dot to directly set the orientation</li>
+                    <li>Click and drag other places on the viewer. A line shows you the axis between the center point and your cursor, for alignment with features in the image. </li>
+                </ul>
                 </p>
                 <p>
                     While the controller is active, hold the shift key to zoom/pan the image. The controller will reactivate after the key press.
@@ -52,7 +53,6 @@
 
                 <h4>Code:</h4>
                 <pre>
-
                     // Must be placed inside a module: script with type="module" for import to work
                     import {RotationControlOverlay} from '../src/js/rotationcontrol.mjs'
 
@@ -75,9 +75,9 @@
                     viewer.addHandler('open',()=>{
                         new RotationControlOverlay(viewer)
                     });
-
                 </pre>
-             </div>
-         </div>
-     </div>
- </body>
+            </div>
+        </div>
+    </div>
+</body>
+</html>

--- a/demo/rotation.html
+++ b/demo/rotation.html
@@ -7,11 +7,11 @@
 
 
     <script type="module">
-        import { AnnotationToolbar } from '../src/js/annotationtoolbar.mjs';
-        import{ AnnotationToolkit } from '../src/js/annotationtoolkit.mjs';
+        import {RotationControlOverlay} from '../src/js/rotationcontrol.mjs'
+
         // Basic viewer setup
         let viewer = OpenSeadragon({
-            element: 'brush-viewer',
+            element: 'rotating-viewer',
             prefixUrl: "https://openseadragon.github.io/openseadragon/images/",
             tileSources: {
                 type: 'image',
@@ -25,39 +25,7 @@
         });
 
         viewer.addHandler('open', () => {
-            let paperScope = new paper.PaperScope(); // Create a new PaperScope
-            paperScope.setup('brush-canvas'); // Set up Paper.js with the specified canvas ID
-
-            // Create the AnnotationToolkit instance with annotationUI selecting a tool and add feature collections
-            let annotationToolkit = new AnnotationToolkit(viewer);
-            annotationToolkit.addAnnotationUI({tools:["select"], addButton:false, addFileButton:false});
-
-            $.get('./demo-annotation.json').then(x => annotationToolkit.addFeatureCollections(x));
-        });
-        
-        let exampleviewer = OpenSeadragon({
-            element: 'example-viewer',
-            prefixUrl: "https://openseadragon.github.io/openseadragon/images/",
-            tileSources: {
-                type: 'image',
-                url: './tissue.jpg',
-                buildPyramid: true
-            },
-            minZoomImageRatio: 0.01,
-            visibilityRatio: 0,
-            crossOriginPolicy: 'Anonymous',
-            ajaxWithCredentials: false
-        });
-
-        exampleviewer.addHandler('open', () => {
-            let exPaperScope = new paper.PaperScope(); // Create a new PaperScope
-            exPaperScope.setup('example-canvas'); // Set up Paper.js with the specified canvas ID
-        
-            // Create the AnnotationToolkit instance for the example viewer
-            let exAnnotationToolkit = new AnnotationToolkit(exampleviewer);
-            exAnnotationToolkit.addAnnotationUI({tools:["select"], addButton:false, addFileButton:false});
-        
-            fetch('./tissue-annotation.json').then(r=>r.json()).then(x => exAnnotationToolkit.addFeatureCollections(x));
+            new RotationControlOverlay(viewer)
         });
     </script>
  </head>
@@ -84,10 +52,10 @@
 
                 <h4>Code:</h4>
                 <pre>
-                    
+
                     // Must be placed inside a module: script with type="module" for import to work
                     import {RotationControlOverlay} from '../src/js/rotationcontrol.mjs'
-            
+
                     // Basic viewer setup
                     let viewer = OpenSeadragon({
                         element:'rotating-viewer',
@@ -102,16 +70,14 @@
                         crossOriginPolicy: 'Anonymous',
                         ajaxWithCredentials: false
                     });
-            
+
                     //Add a RotationControlOverlay to the viewer
                     viewer.addHandler('open',()=>{
                         new RotationControlOverlay(viewer)
                     });
-                    
+
                 </pre>
              </div>
          </div>
      </div>
-     <canvas id="example-canvas" style="display:none;"></canvas>
-     <canvas id="brush-canvas" style="display:none;"></canvas>
  </body>

--- a/demo/select.html
+++ b/demo/select.html
@@ -6,7 +6,6 @@
     <link rel="stylesheet" href="./demo.css">
 
     <script type="module">
-        import { AnnotationToolbar } from '../src/js/annotationtoolbar.mjs';
         import{ AnnotationToolkit } from '../src/js/annotationtoolkit.mjs';
         // Basic viewer setup
         let viewer = window.viewer = OpenSeadragon({
@@ -79,7 +78,7 @@
             <div>
             </div>
         </div>
-        
+
     </div>
 
 </body>

--- a/demo/select.html
+++ b/demo/select.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<html>
 <head>
     <title>Select Tool Demo</title>
     <script type="text/javascript" src="./openseadragon/openseadragon.min.js"></script>
@@ -75,12 +76,8 @@
                     <li><strong>Escape:</strong> Press the 'Escape' key to clear the selection and deselect all items.</li>
                 </ul>
             </div>
-            <div>
-            </div>
         </div>
-
     </div>
-
 </body>
 </html>
 

--- a/demo/style.html
+++ b/demo/style.html
@@ -6,7 +6,6 @@
     <link rel="stylesheet" href="./demo.css">
 
     <script type="module">
-        import { AnnotationToolbar } from '../src/js/annotationtoolbar.mjs';
         import{ AnnotationToolkit } from '../src/js/annotationtoolkit.mjs';
         // Basic viewer setup
         let viewer = window.viewer = OpenSeadragon({
@@ -47,7 +46,7 @@
                 // annotationToolkit.addFeatureCollections(x, true, viewer.world.getItemAt(1));
             });
         });
-        
+
         // let exampleviewer = OpenSeadragon({
         //     element: 'example-viewer',
         //     prefixUrl: "https://openseadragon.github.io/openseadragon/images/",
@@ -65,11 +64,11 @@
         // exampleviewer.addHandler('open', () => {
         //     let exPaperScope = new paper.PaperScope(); // Create a new PaperScope
         //     exPaperScope.setup('example-canvas'); // Set up Paper.js with the specified canvas ID
-        
+
         //     // Create the AnnotationToolkit instance for the example viewer
         //     let exAnnotationToolkit = new AnnotationToolkit(exampleviewer);
         //     exAnnotationToolkit.addAnnotationUI({tools:["style"], addButton:false, addFileButton:false});
-        
+
         //     $.get('./tissue-annotation.json').then(x => exAnnotationToolkit.addFeatureCollections(x));
         // });
     </script>
@@ -95,7 +94,7 @@
                     <li><strong>Cycle through Hierarchy:</strong> Click the "Cycle through Hierarchy" button to cycle through different hierarchy levels of the selected items.</li>
                     <li><strong>Apply and Finish:</strong> Once you are satisfied with the modifications, click the "Apply" button in the tool's toolbar to apply the changes to the selected items. To finish using the Style Tool, click the "Done" button.</li>
                 </ol>
-            
+
                 <div>
                     <h4>Note:</h4>
                     <p>
@@ -127,6 +126,6 @@
                     </ol>
                     <div id="example-viewer" class="viewer"></div>
                 </div> -->
-    
+
 </body>
 </html>

--- a/demo/style.html
+++ b/demo/style.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
+<html>
 <head>
     <title>Style Tool Demo</title>
     <script type="text/javascript" src="./openseadragon/openseadragon.min.js"></script>
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/paper.js/0.12.17/paper-full.js"></script>
     <link rel="stylesheet" href="./demo.css">
-
     <script type="module">
         import{ AnnotationToolkit } from '../src/js/annotationtoolkit.mjs';
         // Basic viewer setup
@@ -126,6 +126,8 @@
                     </ol>
                     <div id="example-viewer" class="viewer"></div>
                 </div> -->
-
+            </div>
+        </div>
+    </div>
 </body>
 </html>

--- a/demo/text.html
+++ b/demo/text.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<html>
 <head>
     <title>Text Tool Demo</title>
     <script type="text/javascript" src="./openseadragon/openseadragon.min.js"></script>
@@ -71,8 +72,8 @@
                         Text annotations created using the Text Toolbox Tool are point-based and may lose scalability when scaled. Ensure that you create annotations at appropriate sizes to maintain clarity in your map.
                     </p>
                 </div>
-
             </div>
         </div>
-    </body>
+    </div>
+</body>
 </html>

--- a/demo/text.html
+++ b/demo/text.html
@@ -6,7 +6,6 @@
     <link rel="stylesheet" href="./demo.css">
 
     <script type="module">
-        import { AnnotationToolbar } from '../src/js/annotationtoolbar.mjs';
         import{ AnnotationToolkit } from '../src/js/annotationtoolkit.mjs';
         // Basic viewer setup
         let viewer = window.viewer = OpenSeadragon({
@@ -65,14 +64,14 @@
                     <li><strong>Customizing the Style:</strong> The text's style can be customized. You can change the font size, stroke width, fill color, etc by using the style tool from the toolkit, please look at the style demo for a more indepth exaplanation. </li>
                     <li><strong>Saving Changes:</strong> Any changes made to the text annotations are automatically saved.</li>
                 </ol>
-            
+
                 <div>
                     <h4>Note:</h4>
                     <p>
                         Text annotations created using the Text Toolbox Tool are point-based and may lose scalability when scaled. Ensure that you create annotations at appropriate sizes to maintain clarity in your map.
                     </p>
                 </div>
-                
+
             </div>
         </div>
     </body>

--- a/demo/transform.html
+++ b/demo/transform.html
@@ -1,3 +1,5 @@
+<!DOCTYPE html>
+<html>
 <head>
     <title>Transform Tool Demo</title>
     <script type="text/javascript" src="./openseadragon/openseadragon.min.js"></script>
@@ -111,8 +113,9 @@
             <div id="example-viewer" class="viewer"></div>
         </div>
 
-    <!-- The canvas used for Paper.js -->
-    <canvas id="example-canvas" style="display:none;"></canvas>
-    <canvas id="brush-canvas" style="display:none;"></canvas>
+        <!-- The canvas used for Paper.js -->
+        <canvas id="example-canvas" style="display:none;"></canvas>
+        <canvas id="brush-canvas" style="display:none;"></canvas>
+    </div>
 </body>
 </html>

--- a/demo/transform.html
+++ b/demo/transform.html
@@ -5,7 +5,6 @@
     <link rel="stylesheet" href="./demo.css">
 
     <script type="module">
-        import { AnnotationToolbar } from '../src/js/annotationtoolbar.mjs';
         import{ AnnotationToolkit } from '../src/js/annotationtoolkit.mjs';
         // Basic viewer setup
         let viewer = OpenSeadragon({
@@ -32,7 +31,7 @@
 
             fetch('./demo-annotation.json').then(r=>r.json()).then(x => annotationToolkit.addFeatureCollections(x));
         });
-        
+
         let exampleviewer = OpenSeadragon({
             element: 'example-viewer',
             prefixUrl: "https://openseadragon.github.io/openseadragon/images/",
@@ -51,11 +50,11 @@
         exampleviewer.addHandler('open', () => {
             let exPaperScope = new paper.PaperScope(); // Create a new PaperScope
             exPaperScope.setup('example-canvas'); // Set up Paper.js with the specified canvas ID
-        
+
             // Create the AnnotationToolkit instance for the example viewer
             let exAnnotationToolkit = new AnnotationToolkit(exampleviewer);
             exAnnotationToolkit.addAnnotationUI({tools:["transform"], addButton:false, addFileButton:false});
-        
+
             fetch('./tissue-annotationtransform.json').then(r=>r.json()).then(x => exAnnotationToolkit.addFeatureCollections(x));
         });
     </script>

--- a/demo/wand.html
+++ b/demo/wand.html
@@ -1,3 +1,5 @@
+<!DOCTYPE html>
+<html>
 <head>
     <title>Magic Wand Tool Demo</title>
     <script type="text/javascript" src="./openseadragon/openseadragon.min.js"></script>
@@ -118,6 +120,8 @@
                     </ol>
                     <div id="example-viewer" class="viewer"></div>
                 </div> -->
-
+            </div>
+        </div>
+    </div>
 </body>
 </html>

--- a/demo/wand.html
+++ b/demo/wand.html
@@ -5,7 +5,6 @@
     <link rel="stylesheet" href="./demo.css">
 
     <script type="module">
-        import { AnnotationToolbar } from '../src/js/annotationtoolbar.mjs';
         import{ AnnotationToolkit } from '../src/js/annotationtoolkit.mjs';
         // Basic viewer setup
         let viewer = window.viewer = OpenSeadragon({
@@ -46,7 +45,7 @@
                 annotationToolkit.addFeatureCollections(x, true, viewer.world.getItemAt(1));
             });
         });
-        
+
         // let exampleviewer = OpenSeadragon({
         //     element: 'example-viewer',
         //     prefixUrl: "https://openseadragon.github.io/openseadragon/images/",
@@ -64,11 +63,11 @@
         // exampleviewer.addHandler('open', () => {
         //     let exPaperScope = new paper.PaperScope(); // Create a new PaperScope
         //     exPaperScope.setup('example-canvas'); // Set up Paper.js with the specified canvas ID
-        
+
         //     // Create the AnnotationToolkit instance for the example viewer
         //     let exAnnotationToolkit = new AnnotationToolkit(exampleviewer);
         //     exAnnotationToolkit.addAnnotationUI({tools:["wand"], addButton:false, addFileButton:false});
-        
+
         //     $.get('./tissue-annotation.json').then(x => exAnnotationToolkit.addFeatureCollections(x));
         // });
     </script>
@@ -93,7 +92,7 @@
                     <li><strong>Threshold Adjustment:</strong> While holding the mouse button down, you can adjust the threshold by dragging the mouse left or right. The selection will update dynamically as you drag.</li>
                     <li><strong>Apply and Finish:</strong> Use the "Apply" button in the tool's toolbar to apply the changes to the selection. If you're done with the selection, click the "Done" button to finish using the Wand Tool.</li>
                 </ol>
-            
+
                 <div>
                     <h4>Note:</h4>
                     <p>


### PR DESCRIPTION
To resolve [error](https://github.com/pearcetm/osd-paperjs-annotation/issues/11).

Additionally, the rotation example was not functioning properly because the toggle button did not appear, so fixed that.

<img width="975" alt="image" src="https://github.com/pearcetm/osd-paperjs-annotation/assets/35016301/f828e457-7617-4ee9-9b80-1d7dfe455bc1">
<img width="983" alt="image" src="https://github.com/pearcetm/osd-paperjs-annotation/assets/35016301/da467eff-abea-437d-8992-2174b8e25537">

+) Fix example-viewer in the raster demo 
<img width="1440" alt="image" src="https://github.com/pearcetm/osd-paperjs-annotation/assets/35016301/f059ddc3-b7ff-4aa1-afa1-c8986de5463f">
<img width="1438" alt="image" src="https://github.com/pearcetm/osd-paperjs-annotation/assets/35016301/3a0fd2d5-6c84-4deb-9451-542cb192aa96">
